### PR TITLE
Allow the npm installed svg-to-elm command to successfully run

### DIFF
--- a/bin/svg-to-elm.ts
+++ b/bin/svg-to-elm.ts
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 import Parser, { ParsingError } from '../src/parser';
 import { ElmModule } from '../src/types';
 


### PR DESCRIPTION
Fixes GH-2

[From the NPM package.json documentation](https://docs.npmjs.com/files/package.json#bin):

> Please make sure that your file(s) referenced in "bin" starts with #!/usr/bin/env node, otherwise the scripts are started without the node executable!

The TypeScript compiler recognises that a shebang as the first line of the `.ts` file should be copied verbatim to the compiled `.js` file (in this case, `lib/bin/svg-to-elm.js`).
